### PR TITLE
Add new anonymous version of the Helix plugin

### DIFF
--- a/buildtasks-anon-extension.json
+++ b/buildtasks-anon-extension.json
@@ -1,0 +1,50 @@
+{
+    "manifestVersion": 1,
+    "id": "dnceng-anon-build-release-tasks",
+    "name": "Dnceng Tools",
+    "version": "0.0.1",
+    "publisher": "dotnet-dnceng",
+    "targets": [
+        {
+            "id": "Microsoft.VisualStudio.Services"
+        }
+    ],    
+    "description": "Tasks for building in dnceng.",
+    "categories": [
+        "Azure Pipelines"
+    ],
+    "icons": {
+        "default": "images/dotnet-bot-128.jpg"
+    },
+    "files": [
+        {
+            "path": "src/helix-anon/index.html",
+            "packagePath": "helix/index.html",
+            "addressable": true
+        },
+        {
+            "path": "src/helix-anon/node_modules/vss-web-extension-sdk/lib",
+            "packagePath": "helix/node_modules/vss-web-extension-sdk/lib",
+            "addressable": true
+        }  
+    ],
+    "contributions": [
+        {
+            "id": "helix-anon-test-information-tab",
+            "type": "ms.vss-web.tab",
+            "description": "Adds a tab to the test results view",
+            "targets": [
+                "ms.vss-test-web.test-result-details-tab-items"
+            ],
+            "properties": {
+                "uri": "helix/index.html",
+                "title": "Helix Test Logs (Beta)",
+                "name": "Helix Test Logs (Beta)"
+            },
+            "restrictedTo": [
+                "public",
+                "anonymous"
+            ]
+        }
+    ]
+}

--- a/buildtasks-extension.json
+++ b/buildtasks-extension.json
@@ -85,7 +85,10 @@
                 "uri": "helix/index.html",
                 "title": "Helix Test Logs (Beta)",
                 "name": "Helix Test Logs (Beta)"
-            }
+            }, 
+            "restrictedTo": [
+                "member"
+            ]
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,15 @@
   "main": "",
   "scripts": {
     "restore-helix": "cd src/helix && npm install",
+    "restore-helix-anon": "cd src/helix-anon && npm install",
     "restore-tasks": "cd src/tasks && npm install",
-    "restore": "npm run restore-helix && npm run restore-tasks",
+    "restore": "npm run restore-helix && npm run restore-helix-anon && npm run restore-tasks",
     "prebuild": "npm run restore",
     "build-tasks": "node src/tasks/make.js build",
     "build": "npm run build-tasks",
-    "pack": "tfx extension create --manifest-globs buildtasks-extension.json --output-path .artifacts/packages"
+    "pack-tasks": "tfx extension create --manifest-globs buildtasks-extension.json --output-path .artifacts/packages",
+    "pack-helix-anon": "tfx extension create --manifest-globs buildtasks-anon-extension.json --output-path .artifacts/packages",
+    "pack": "npm run pack-tasks && npm run pack-helix-anon"
   },
   "repository": {
     "type": "git",

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -1,0 +1,88 @@
+<html>
+
+<head>
+  <title>Helix Test Logs (Beta)</title>
+  <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
+  <style>
+    .loading {
+      animation: rotation .6s infinite linear;
+      border-left: 6px solid rgba(0, 174, 239, .15);
+      border-right: 6px solid rgba(0, 174, 239, .15);
+      border-bottom: 6px solid rgba(0, 174, 239, .15);
+      border-top: 6px solid rgba(0, 174, 239, .8);
+      -ms-border-radius: 100%;
+      border-radius: 100%;
+    }
+
+    .loading.center {
+      width: 100px;
+      height: 100px;
+      position: absolute;
+      left: calc(50% - 50px);
+      top: calc(50% - 50px);
+    }
+
+    @keyframes rotation {
+      from {
+        transform: rotate(0);
+      }
+
+      to {
+        transform: rotate(359deg);
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div id="content">
+    <div class="loading center"></div>
+  </div>
+
+  <script type="text/javascript">
+    VSS.init({ explicitNotifyLoaded: true, usePlatformScripts: true, usePlatformStyles: true, extensionReusedCallback: registerContribution });
+    // We need to register the new contribution if this extension host is reused
+    function registerContribution(contribution) {
+      updateConfiguration(VSS.getConfiguration());
+      VSS.register(contribution.id, {
+        pageTitle: "Helix Test Logs (Beta)",
+        updateContext: updateConfiguration,
+        isInvisible: function (state) {
+          // tab is always visible
+          return false;
+        }
+      });
+    }
+    function updateConfiguration(tabContext) {
+      if (typeof tabContext !== "object") {
+        return;
+      }
+
+      var webContext = VSS.getWebContext();
+      var testRunId = tabContext["runId"];
+      var testResultId = tabContext["resultId"];
+
+      var url = "https://dev.azure.com/dnceng/" + webContext.project.name + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
+      window.fetch(url)
+        .then(response => response.json())
+        .then(result => {
+          var data = JSON.parse(result.comment);
+          var jobId = data.HelixJobId;
+          var workItemName = data.HelixWorkItemName;
+          var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+
+          window.location.href = link;
+        }).catch(() => {
+          document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data</h3>"
+        });
+    };
+
+    // Show context info when ready
+    VSS.ready(function () {
+      registerContribution(VSS.getContribution());
+      VSS.notifyLoadSucceeded();
+    });
+  </script>
+</body>
+
+</html>

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -61,9 +61,12 @@
       var webContext = VSS.getWebContext();
       var testRunId = tabContext["runId"];
       var testResultId = tabContext["resultId"];
+      
+      var projectName = webContext.project.name;
+      var organizationUrl = webContext.collection.uri;
 
-      var url = "https://dev.azure.com/dnceng/" + webContext.project.name + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
-      window.fetch(url)
+      var getTestResultUrl = organizationUrl + projectName + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
+      window.fetch(getTestResultUrl)
         .then(response => response.json())
         .then(result => {
           var data = JSON.parse(result.comment);

--- a/src/helix-anon/package-lock.json
+++ b/src/helix-anon/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "helix-anon",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/jquery": {
+      "version": "3.3.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.30.tgz",
+      "integrity": "sha512-chB+QbLulamShZAFcTJtl8opZwHFBpDOP6nRLrPGkhC6N1aKWrDXg2Nc71tEg6ny6E8SQpRwbWSi9GdstH5VJA==",
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/jqueryui": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.7.tgz",
+      "integrity": "sha512-MpHuknhR20kBNsDA2VAM6WZGc+CMApzfKfTZuzMOH2dEUzo5POPGicfGJ647wvl2T6ZgQKPCSWmCUhna3XpX0Q==",
+      "requires": {
+        "@types/jquery": "*"
+      }
+    },
+    "@types/knockout": {
+      "version": "3.4.66",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.66.tgz",
+      "integrity": "sha512-UNmyr4mM/y/AvQ6eQmd9v+9/QDZUxiudFb6U/sqIvKlQtAiUO5RM52YRP88CQzYOztxWw0t1feeFIKN3R4Q2Ow=="
+    },
+    "@types/mousetrap": {
+      "version": "1.5.34",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.5.34.tgz",
+      "integrity": "sha512-a2yhRIADupQfOFM75v7GfcQQLUxU705+i/xcZ3N/3PK3Xdo31SUfuCUByWPGOHB1e38m7MxTx/D8FPVsJXZKJw=="
+    },
+    "@types/q": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU="
+    },
+    "@types/react": {
+      "version": "15.6.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.26.tgz",
+      "integrity": "sha512-wNoXCIzRp2dBHch6fekXU6PRbjHs/VjK1yXNFfPRiBM54Vt3yQt9F5Yb4e34AU1c+mdyxLh6e1AVdvfplI1RMQ=="
+    },
+    "@types/requirejs": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/@types/requirejs/-/requirejs-2.1.31.tgz",
+      "integrity": "sha512-b2soeyuU76rMbcRJ4e0hEl0tbMhFwZeTC0VZnfuWlfGlk6BwWNsev6kFu/twKABPX29wkX84wU2o+cEJoXsiTw=="
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+    },
+    "vss-web-extension-sdk": {
+      "version": "5.141.0",
+      "resolved": "https://registry.npmjs.org/vss-web-extension-sdk/-/vss-web-extension-sdk-5.141.0.tgz",
+      "integrity": "sha512-c/r/HWQh4hljKOSNQMiFoeICckKFfU/1nxDCVFhioDHOE8B0i5aJN9rrihGilgMXugzl8K5hBsZs42eFqd30AQ==",
+      "requires": {
+        "@types/jquery": ">=2.0.48",
+        "@types/jqueryui": ">=1.11.34",
+        "@types/knockout": "^3.4.49",
+        "@types/mousetrap": "~1.5.34",
+        "@types/q": "0.0.32",
+        "@types/react": "^15.6.12",
+        "@types/requirejs": ">=2.1.28"
+      }
+    }
+  }
+}

--- a/src/helix-anon/package.json
+++ b/src/helix-anon/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "helix-anon",
+  "version": "1.0.0",
+  "description": "",
+  "main": "",
+  "scripts": {},
+  "author": "Microsoft",
+  "license": "MIT",
+  "dependencies": {
+    "vss-web-extension-sdk": "^5.141.0"
+  }
+}


### PR DESCRIPTION
Candidate fix for dotnet/core-eng#12689.

Currently the "Helix Results" tab added to the Test Results view in Azure DevOps is not shown to unauthenticated users. It is desired that all users be able to view this data (when the data itself is also public). 

Azure DevOps extension implementation prevents this in a single plugin:

- Using the SDK "Test Management" client requires adding the "Test Read" scope to the plugin. This prevents unauthenticated users from even seeing the tab. This despite that test result data is anonymously accessible by public projects.
- Removing the "Test Read" scope prevents any access to the "Test Management" client provided by the SDK. So unauthenticated users could see the tab but neither unauthenticated nor authenticated users could retrieve data.

This PR creates a second, nearly duplicate Helix plugin with some important changes:

- The scope requirement is removed (the manifest declares no special permission requirements from users)
- The contribution is restricted to "anonymous" (unauthenticated) and "public" (authenticated to Azure DevOps but not a member of the project) users. This means this plugin is _only_ shown to users in these groups. 
- The plugin uses a manual, unauthenticated HTTP GET rather than the Azure DevOps SDK to gather the information necessary to display the Helix logs.

This also modifies the original plugin to be restricted to "members" (authenticated, known users) to avoid showing to tabs to users.

I have this available in a separate Azure DevOps instance for testing. 