### PR TITLE
Distinguish anonymous extension by name

### DIFF
--- a/buildtasks-anon-extension.json
+++ b/buildtasks-anon-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "dnceng-anon-build-release-tasks",
-    "name": "Dnceng Tools",
+    "name": "Dnceng Tools Anonymous",
     "version": "0.0.1",
     "publisher": "dotnet-dnceng",
     "targets": [


### PR DESCRIPTION
Missed a change that should've been part of dotnet/arcade-extensions#22 