### PR TITLE
add sbom generation steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,41 +4,46 @@ trigger:
 pr:
   - main
 
-jobs:
-- job: build_Windows
-  displayName: Build (Windows)
-  pool:
+stages:
+- stage: Build
+  displayName: Build
+  jobs:
+  - job: build_Windows
+    displayName: Build (Windows)
+    pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       vmImage: windows-2019
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals build.windows.10.amd64.vs2019
 
+    steps:
+    - checkout: self
+      clean: all
 
-  steps:
-  - checkout: self
-    clean: all
+    - task: NodeTool@0
+      displayName: Use node 10
+      inputs:
+        versionSpec: "10.x"
 
-  - task: NodeTool@0
-    displayName: Use node 10
-    inputs:
-      versionSpec: "10.x"
+    # restore
+    - script: restore.cmd
+      displayName: Restore
+    # Build
+    - script: build.cmd
+      displayName: Build
 
-  # restore
-  - script: restore.cmd
-    displayName: Restore
-  # Build
-  - script: build.cmd
-    displayName: Build
+    # Package Extension
+    - script: package.cmd
+      displayName: Package Extension
 
-  # Package Extension
-  - script: package.cmd
-    displayName: Package Extension
+    # Generate SBOM
+    - template: eng\generate-sbom.yml
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish extension artifact
-    condition: succeeded()
-    inputs:
-      pathToPublish: .artifacts\packages
-      artifactName: Extensions
-      publishLocation: container
+    - task: PublishBuildArtifacts@1
+      displayName: Publish extension artifact
+      condition: succeeded()
+      inputs:
+        pathToPublish: .artifacts\packages
+        artifactName: Extensions
+        publishLocation: container

--- a/eng/generate-sbom-prep.ps1
+++ b/eng/generate-sbom-prep.ps1
@@ -1,0 +1,19 @@
+Param(
+    [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
+)
+
+Write-Host "Creating dir $ManifestDirPath"
+# create directory for sbom manifest to be placed
+if (!(Test-Path -path $ManifestDirPath))
+{
+  New-Item -ItemType Directory -path $ManifestDirPath
+  Write-Host "Successfully created directory $ManifestDirPath"
+}
+else{
+  Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
+}
+
+Write-Host "Updating artifact name"
+$artifact_name = "${env:SYSTEM_STAGENAME}_${env:AGENT_JOBNAME}_SBOM" -replace '["/:<>\\|?@*"() ]', '_'
+Write-Host "Artifact name $artifact_name"
+Write-Host "##vso[task.setvariable variable=ARTIFACT_NAME]$artifact_name"

--- a/eng/generate-sbom.yml
+++ b/eng/generate-sbom.yml
@@ -1,0 +1,36 @@
+# BuildDropPath - The root folder of the drop directory for which the manifest file will be generated.
+# PackageName - The name of the package this SBOM represents.
+# PackageVersion - The version of the package this SBOM represents. 
+# ManifestDirPath - The path of the directory where the generated manifest files will be placed
+
+parameters:
+  PackageVersion: 7.0.0
+  BuildDropPath: '$(Build.SourcesDirectory)/.artifacts'
+  PackageName: '.NET'
+  ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+  sbomContinueOnError: true
+
+steps:
+- task: PowerShell@2 
+  displayName: Prep for SBOM generation in (Non-linux)
+  condition: or(eq(variables['Agent.Os'], 'Windows_NT'), eq(variables['Agent.Os'], 'Darwin'))
+  inputs: 
+    filePath: ./eng/generate-sbom-prep.ps1
+    arguments: ${{parameters.manifestDirPath}}
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Generate SBOM manifest'
+  continueOnError: ${{ parameters.sbomContinueOnError }}
+  inputs:
+      PackageName: ${{ parameters.packageName }}
+      BuildDropPath: ${{ parameters.buildDropPath }}
+      PackageVersion: ${{ parameters.packageVersion }}
+      ManifestDirPath: ${{ parameters.manifestDirPath }}
+
+- task: PublishPipelineArtifact@1
+  displayName: Publish SBOM manifest
+  continueOnError: ${{parameters.sbomContinueOnError}}
+  inputs:
+    targetPath: '${{parameters.manifestDirPath}}'
+    artifactName: $(ARTIFACT_NAME)
+


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/8550

uses slightly modified template and script from arcade. I Added a stage to the build, so there's some indentation changes in the build steps. Should be easier to review ignoring whitespace

Test build with sbom generation enabled: https://dev.azure.com/dnceng/internal/_build/results?buildId=1643617&view=results

The sbom looked correct