### PR TITLE
Clear up message in "Artifact" panel when not a helix test

### DIFF
--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -81,10 +81,10 @@
             }
           }
           else {
-            document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+            document.getElementById("content").innerHTML = "<h3>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
           }
         }).catch(() => {
-                document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+                document.getElementById("content").innerHTML = "<h3>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
        });
     };
 

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -1,93 +1,92 @@
 <html>
 
 <head>
-    <title>Helix Artifacts</title>
-    <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
-    <style>
-        .loading {
-            animation: rotation .6s infinite linear;
-            border-left: 6px solid rgba(0, 174, 239, .15);
-            border-right: 6px solid rgba(0, 174, 239, .15);
-            border-bottom: 6px solid rgba(0, 174, 239, .15);
-            border-top: 6px solid rgba(0, 174, 239, .8);
-            -ms-border-radius: 100%;
-            border-radius: 100%;
-        }
+  <title>Helix Artifacts</title>
+  <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
+  <style>
+    .loading {
+      animation: rotation .6s infinite linear;
+      border-left: 6px solid rgba(0, 174, 239, .15);
+      border-right: 6px solid rgba(0, 174, 239, .15);
+      border-bottom: 6px solid rgba(0, 174, 239, .15);
+      border-top: 6px solid rgba(0, 174, 239, .8);
+      -ms-border-radius: 100%;
+      border-radius: 100%;
+    }
 
-        .loading.center {
-            width: 100px;
-            height: 100px;
-            position: absolute;
-            left: calc(50% - 50px);
-            top: calc(50% - 50px);
-        }
+    .loading.center {
+      width: 100px;
+      height: 100px;
+      position: absolute;
+      left: calc(50% - 50px);
+      top: calc(50% - 50px);
+    }
 
-        @keyframes rotation {
-            from {
-                transform: rotate(0);
-            }
+    @keyframes rotation {
+      from {
+        transform: rotate(0);
+      }
 
-            to {
-                transform: rotate(359deg);
-            }
-        }
-    </style>
+      to {
+        transform: rotate(359deg);
+      }
+    }
+  </style>
 </head>
 
 <body>
-<div id="content">
+  <div id="content">
     <div class="loading center"></div>
-</div>
+  </div>
 
-<script type="text/javascript">
+  <script type="text/javascript">
     VSS.init({ explicitNotifyLoaded: true, usePlatformScripts: true, usePlatformStyles: true, extensionReusedCallback: registerContribution });
     // We need to register the new contribution if this extension host is reused
     function registerContribution(contribution) {
-        updateConfiguration(VSS.getConfiguration());
-        VSS.register(contribution.id, {
-            pageTitle: "Helix Artifacts",
-                updateContext: updateConfiguration,
-                isInvisible: function (state) {
-                    // tab is always visible
-                    return false;
-                }
-            });
+      updateConfiguration(VSS.getConfiguration());
+      VSS.register(contribution.id, {
+        pageTitle: "Helix Artifacts",
+        updateContext: updateConfiguration,
+        isInvisible: function (state) {
+          // tab is always visible
+          return false;
+        }
+      });
     }
     function updateConfiguration(tabContext) {
-        if (typeof tabContext !== "object") {
-            return;
-        }
+      if (typeof tabContext !== "object") {
+        return;
+      }
 
-        var webContext = VSS.getWebContext();
-        var testRunId = tabContext["runId"];
-        var testResultId = tabContext["resultId"];
+      var webContext = VSS.getWebContext();
+      var testRunId = tabContext["runId"];
+      var testResultId = tabContext["resultId"];
 
-        var projectName = webContext.project.name;
-        var organizationUrl = webContext.collection.uri;
+      var projectName = webContext.project.name;
+      var organizationUrl = webContext.collection.uri;
 
-        var getTestResultUrl = organizationUrl + projectName + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
-        window.fetch(getTestResultUrl)
-            .then(response => response.json())
-            .then(result => {
-                var helixWorkItem = TryGetHelix(result.comment);
-                if (helixWorkItem.IsHelixWorkItem) {
-                    try {
-                        var jobId = helixWorkItem.HelixJobId;
-                        var workItemName = helixWorkItem.HelixWorkItemName;
-                        var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+      var getTestResultUrl = organizationUrl + projectName + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
+      window.fetch(getTestResultUrl)
+        .then(response => response.json())
+        .then(result => {
+          var helixWorkItem = TryGetHelix(result.comment);
+          if (helixWorkItem.IsHelixWorkItem) {
+            try {
+              var jobId = helixWorkItem.HelixJobId;
+              var workItemName = helixWorkItem.HelixWorkItemName;
+              var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
 
-                        window.location.href = link;
-                    } catch (e) {
-                        document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
-                    }
-
-                } else {
-                    document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
-                }
-
-            }).catch(() => {
+              window.location.href = link;
+            } catch (e) {
+              document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
+            }
+          }
+          else {
+            document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+          }
+        }).catch(() => {
                 document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
-            });
+       });
     };
 
     function TryGetHelix(comment) {
@@ -114,10 +113,10 @@
 
     // Show context info when ready
     VSS.ready(function () {
-        registerContribution(VSS.getContribution());
-        VSS.notifyLoadSucceeded();
+      registerContribution(VSS.getContribution());
+      VSS.notifyLoadSucceeded();
     });
-</script>
+  </script>
 </body>
 
 </html>

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -61,7 +61,6 @@
       var webContext = VSS.getWebContext();
       var testRunId = tabContext["runId"];
       var testResultId = tabContext["resultId"];
-
       var projectName = webContext.project.name;
       var organizationUrl = webContext.collection.uri;
 
@@ -109,8 +108,6 @@
             return { 'IsHelixWorkItem': false };
         }
     }
-
-
     // Show context info when ready
     VSS.ready(function () {
       registerContribution(VSS.getContribution());

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -1,91 +1,123 @@
 <html>
 
 <head>
-  <title>Helix Artifacts</title>
-  <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
-  <style>
-    .loading {
-      animation: rotation .6s infinite linear;
-      border-left: 6px solid rgba(0, 174, 239, .15);
-      border-right: 6px solid rgba(0, 174, 239, .15);
-      border-bottom: 6px solid rgba(0, 174, 239, .15);
-      border-top: 6px solid rgba(0, 174, 239, .8);
-      -ms-border-radius: 100%;
-      border-radius: 100%;
-    }
+    <title>Helix Artifacts</title>
+    <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
+    <style>
+        .loading {
+            animation: rotation .6s infinite linear;
+            border-left: 6px solid rgba(0, 174, 239, .15);
+            border-right: 6px solid rgba(0, 174, 239, .15);
+            border-bottom: 6px solid rgba(0, 174, 239, .15);
+            border-top: 6px solid rgba(0, 174, 239, .8);
+            -ms-border-radius: 100%;
+            border-radius: 100%;
+        }
 
-    .loading.center {
-      width: 100px;
-      height: 100px;
-      position: absolute;
-      left: calc(50% - 50px);
-      top: calc(50% - 50px);
-    }
+        .loading.center {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+            left: calc(50% - 50px);
+            top: calc(50% - 50px);
+        }
 
-    @keyframes rotation {
-      from {
-        transform: rotate(0);
-      }
+        @keyframes rotation {
+            from {
+                transform: rotate(0);
+            }
 
-      to {
-        transform: rotate(359deg);
-      }
-    }
-  </style>
+            to {
+                transform: rotate(359deg);
+            }
+        }
+    </style>
 </head>
 
 <body>
-  <div id="content">
+<div id="content">
     <div class="loading center"></div>
-  </div>
+</div>
 
-  <script type="text/javascript">
+<script type="text/javascript">
     VSS.init({ explicitNotifyLoaded: true, usePlatformScripts: true, usePlatformStyles: true, extensionReusedCallback: registerContribution });
     // We need to register the new contribution if this extension host is reused
     function registerContribution(contribution) {
-      updateConfiguration(VSS.getConfiguration());
-      VSS.register(contribution.id, {
-        pageTitle: "Helix Artifacts",
-        updateContext: updateConfiguration,
-        isInvisible: function (state) {
-          // tab is always visible
-          return false;
-        }
-      });
+        updateConfiguration(VSS.getConfiguration());
+        VSS.register(contribution.id, {
+            pageTitle: "Helix Artifacts",
+                updateContext: updateConfiguration,
+                isInvisible: function (state) {
+                    // tab is always visible
+                    return false;
+                }
+            });
     }
     function updateConfiguration(tabContext) {
-      if (typeof tabContext !== "object") {
-        return;
-      }
+        if (typeof tabContext !== "object") {
+            return;
+        }
 
-      var webContext = VSS.getWebContext();
-      var testRunId = tabContext["runId"];
-      var testResultId = tabContext["resultId"];
-      
-      var projectName = webContext.project.name;
-      var organizationUrl = webContext.collection.uri;
+        var webContext = VSS.getWebContext();
+        var testRunId = tabContext["runId"];
+        var testResultId = tabContext["resultId"];
 
-      var getTestResultUrl = organizationUrl + projectName + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
-      window.fetch(getTestResultUrl)
-        .then(response => response.json())
-        .then(result => {
-          var data = JSON.parse(result.comment);
-          var jobId = data.HelixJobId;
-          var workItemName = data.HelixWorkItemName;
-          var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+        var projectName = webContext.project.name;
+        var organizationUrl = webContext.collection.uri;
 
-          window.location.href = link;
-        }).catch(() => {
-          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, please use the other tabs</h3>"
-        });
+        var getTestResultUrl = organizationUrl + projectName + "/_apis/test/Runs/" + testRunId + "/results/" + testResultId + "?api-version=6.0";
+        window.fetch(getTestResultUrl)
+            .then(response => response.json())
+            .then(result => {
+                var helixWorkItem = TryGetHelix(result.comment);
+                if (helixWorkItem.IsHelixWorkItem) {
+                    try {
+                        var jobId = helixWorkItem.HelixJobId;
+                        var workItemName = helixWorkItem.HelixWorkItemName;
+                        var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+
+                        window.location.href = link;
+                    } catch (e) {
+                        document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
+                    }
+
+                } else {
+                    document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+                }
+
+            }).catch(() => {
+                document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+            });
     };
+
+    function TryGetHelix(comment) {
+        if (comment == null) {
+            return { 'IsHelixWorkItem': false };
+        }
+        try {
+            var data = JSON.parse(comment);
+            var jobId = data.HelixJobId;
+            var workItemName = data.HelixWorkItemName;
+            if (jobId == null || workItemName == null) {
+                return { 'IsHelixWorkItem': false };
+            }
+            return {
+                'IsHelixWorkItem': true,
+                'JobId': jobId,
+                'WorkItemName': workItemName
+            };
+        } catch (error) {
+            return { 'IsHelixWorkItem': false };
+        }
+    }
+
 
     // Show context info when ready
     VSS.ready(function () {
-      registerContribution(VSS.getContribution());
-      VSS.notifyLoadSucceeded();
+        registerContribution(VSS.getContribution());
+        VSS.notifyLoadSucceeded();
     });
-  </script>
+</script>
 </body>
 
 </html>

--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -76,7 +76,7 @@
 
           window.location.href = link;
         }).catch(() => {
-          document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data</h3>"
+          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, please use the other tabs</h3>"
         });
     };
 

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -88,10 +88,10 @@
             }
           }
           else {
-              document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+              document.getElementById("content").innerHTML = "<h3>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
           }
        }).catch(() => {
-          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+          document.getElementById("content").innerHTML = "<h3>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
        });
     });
   }

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -82,7 +82,7 @@
             window.location.href = link;
           }
         }).catch(() => {
-          document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data</h3>"
+          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, please use the other tabs</h3>"
         });
       });
     }

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -1,97 +1,126 @@
 <html>
 
 <head>
-  <title>Helix Artifacts</title>
-  <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
-  <style>
-    .loading {
-      animation: rotation .6s infinite linear;
-      border-left: 6px solid rgba(0, 174, 239, .15);
-      border-right: 6px solid rgba(0, 174, 239, .15);
-      border-bottom: 6px solid rgba(0, 174, 239, .15);
-      border-top: 6px solid rgba(0, 174, 239, .8);
-      -ms-border-radius: 100%;
-      border-radius: 100%;
-    }
+    <title>Helix Artifacts</title>
+    <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
+    <style>
+        .loading {
+            animation: rotation .6s infinite linear;
+            border-left: 6px solid rgba(0, 174, 239, .15);
+            border-right: 6px solid rgba(0, 174, 239, .15);
+            border-bottom: 6px solid rgba(0, 174, 239, .15);
+            border-top: 6px solid rgba(0, 174, 239, .8);
+            -ms-border-radius: 100%;
+            border-radius: 100%;
+        }
 
-    .loading.center {
-      width: 100px;
-      height: 100px;
-      position: absolute;
-      left: calc(50% - 50px);
-      top: calc(50% - 50px);
-    }
+        .loading.center {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+            left: calc(50% - 50px);
+            top: calc(50% - 50px);
+        }
 
-    @keyframes rotation {
-      from {
-        transform: rotate(0);
-      }
+        @keyframes rotation {
+            from {
+                transform: rotate(0);
+            }
 
-      to {
-        transform: rotate(359deg);
-      }
-    }
-  </style>
+            to {
+                transform: rotate(359deg);
+            }
+        }
+    </style>
 </head>
 
 <body>
-  <div id="content">
+<div id="content">
     <div class="loading center"></div>
-  </div>
+</div>
 
-  <script type="text/javascript">
+<script type="text/javascript">
     VSS.init({ explicitNotifyLoaded: true, usePlatformScripts: true, usePlatformStyles: true, extensionReusedCallback: registerContribution });
     // We need to register the new contribution if this extension host is reused
     function registerContribution(contribution) {
-      updateConfiguration(VSS.getConfiguration());
-      VSS.register(contribution.id, {
-        pageTitle: "Helix Artifacts",
-        updateContext: updateConfiguration,
-        isInvisible: function (state) {
-          // tab is always visible
-          return false;
-        }
-      });
+        updateConfiguration(VSS.getConfiguration());
+        VSS.register(contribution.id, {
+            pageTitle: "Helix Artifacts",
+            updateContext: updateConfiguration,
+            isInvisible: function (state) {
+                // tab is always visible
+                return false;
+            }
+        });
     }
     function updateConfiguration(tabContext) {
-      if (typeof tabContext !== "object") {
-        return;
-      }
+        if (typeof tabContext !== "object") {
+            return;
+        }
 
-      var webContext = VSS.getWebContext();
-      var testRunId = tabContext["runId"];
-      var testResultId = tabContext["resultId"];
-      VSS.require(["TFS/TestManagement/RestClient"], function (TestApi) {
-        var client = TestApi.getClient();
-        client.getTestResultById(
-          webContext.project.name,
-          testRunId,
-          testResultId,
-        ).then(result => {
-          var data = JSON.parse(result.comment);
-          var jobId = data.HelixJobId;
-          var workItemName = data.HelixWorkItemName;
-          var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
-          if (webContext.project.name !== "public") {
-            return VSS.getAppToken().then(tokenObj => {
-              link += "&extensionToken=" + encodeURIComponent(tokenObj.token);
-              window.location.href = link;
+        var webContext = VSS.getWebContext();
+        var testRunId = tabContext["runId"];
+        var testResultId = tabContext["resultId"];
+        VSS.require(["TFS/TestManagement/RestClient"], function (TestApi) {
+            var client = TestApi.getClient();
+            client.getTestResultById(
+                webContext.project.name,
+                testRunId,
+                testResultId,
+            ).then(result => {
+                var helixWorkItem = TryGetHelix(result.comment);
+                if (helixWorkItem.IsHelixWorkItem) {
+                    try {
+                        var jobId = helixWorkItem.JobId;
+                        var workItemName = helixWorkItem.WorkItemName;
+                        var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+                        if (webContext.project.name !== "public") {
+                            return VSS.getAppToken().then(tokenObj => {
+                                link += "&extensionToken=" + encodeURIComponent(tokenObj.token);
+                                window.location.href = link;
+                            });
+                        } else {
+                            window.location.href = link;
+                        }
+                    } catch (e) {
+                        document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
+                    }
+                } else {
+                    document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+                }
+            }).catch(() => {
+                document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
             });
-          }
-          else {
-            window.location.href = link;
-          }
-        }).catch(() => {
-          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, please use the other tabs</h3>"
         });
-      });
     }
+
+    function TryGetHelix(comment) {
+        if (comment == null) {
+            return { 'IsHelixWorkItem': false };
+        }
+        try {
+            var data = JSON.parse(comment);
+            var jobId = data.HelixJobId;
+            var workItemName = data.HelixWorkItemName;
+            if (jobId == null || workItemName == null) {
+                return { 'IsHelixWorkItem': false };
+            }
+            return {
+                'IsHelixWorkItem': true,
+                'JobId': jobId,
+                'WorkItemName': workItemName
+            };
+        } catch (error) {
+            return { 'IsHelixWorkItem': false };
+        }
+    }
+
     // Show context info when ready
     VSS.ready(function () {
-      registerContribution(VSS.getContribution());
-      VSS.notifyLoadSucceeded();
+        registerContribution(VSS.getContribution());
+        VSS.notifyLoadSucceeded();
     });
-  </script>
+</script>
 </body>
 
 </html>

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -116,7 +116,6 @@
         return { 'IsHelixWorkItem': false };
       }
     }
-
     // Show context info when ready
     VSS.ready(function () {
       registerContribution(VSS.getContribution());

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -1,126 +1,128 @@
 <html>
 
 <head>
-    <title>Helix Artifacts</title>
-    <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
-    <style>
-        .loading {
-            animation: rotation .6s infinite linear;
-            border-left: 6px solid rgba(0, 174, 239, .15);
-            border-right: 6px solid rgba(0, 174, 239, .15);
-            border-bottom: 6px solid rgba(0, 174, 239, .15);
-            border-top: 6px solid rgba(0, 174, 239, .8);
-            -ms-border-radius: 100%;
-            border-radius: 100%;
-        }
+  <title>Helix Artifacts</title>
+  <script src="node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
+  <style>
+    .loading {
+      animation: rotation .6s infinite linear;
+      border-left: 6px solid rgba(0, 174, 239, .15);
+      border-right: 6px solid rgba(0, 174, 239, .15);
+      border-bottom: 6px solid rgba(0, 174, 239, .15);
+      border-top: 6px solid rgba(0, 174, 239, .8);
+      -ms-border-radius: 100%;
+      border-radius: 100%;
+    }
 
-        .loading.center {
-            width: 100px;
-            height: 100px;
-            position: absolute;
-            left: calc(50% - 50px);
-            top: calc(50% - 50px);
-        }
+    .loading.center {
+      width: 100px;
+      height: 100px;
+      position: absolute;
+      left: calc(50% - 50px);
+      top: calc(50% - 50px);
+    }
 
-        @keyframes rotation {
-            from {
-                transform: rotate(0);
-            }
+    @keyframes rotation {
+      from {
+        transform: rotate(0);
+      }
 
-            to {
-                transform: rotate(359deg);
-            }
-        }
-    </style>
+      to {
+        transform: rotate(359deg);
+      }
+    }
+  </style>
 </head>
 
 <body>
-<div id="content">
+  <div id="content">
     <div class="loading center"></div>
-</div>
+  </div>
 
-<script type="text/javascript">
+  <script type="text/javascript">
     VSS.init({ explicitNotifyLoaded: true, usePlatformScripts: true, usePlatformStyles: true, extensionReusedCallback: registerContribution });
     // We need to register the new contribution if this extension host is reused
     function registerContribution(contribution) {
-        updateConfiguration(VSS.getConfiguration());
-        VSS.register(contribution.id, {
-            pageTitle: "Helix Artifacts",
-            updateContext: updateConfiguration,
-            isInvisible: function (state) {
-                // tab is always visible
-                return false;
-            }
-        });
+      updateConfiguration(VSS.getConfiguration());
+      VSS.register(contribution.id, {
+        pageTitle: "Helix Artifacts",
+        updateContext: updateConfiguration,
+        isInvisible: function (state) {
+          // tab is always visible
+          return false;
+        }
+      });
     }
     function updateConfiguration(tabContext) {
-        if (typeof tabContext !== "object") {
-            return;
-        }
+      if (typeof tabContext !== "object") {
+        return;
+      }
 
-        var webContext = VSS.getWebContext();
-        var testRunId = tabContext["runId"];
-        var testResultId = tabContext["resultId"];
-        VSS.require(["TFS/TestManagement/RestClient"], function (TestApi) {
-            var client = TestApi.getClient();
-            client.getTestResultById(
-                webContext.project.name,
-                testRunId,
-                testResultId,
-            ).then(result => {
-                var helixWorkItem = TryGetHelix(result.comment);
-                if (helixWorkItem.IsHelixWorkItem) {
-                    try {
-                        var jobId = helixWorkItem.JobId;
-                        var workItemName = helixWorkItem.WorkItemName;
-                        var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
-                        if (webContext.project.name !== "public") {
-                            return VSS.getAppToken().then(tokenObj => {
-                                link += "&extensionToken=" + encodeURIComponent(tokenObj.token);
-                                window.location.href = link;
-                            });
-                        } else {
-                            window.location.href = link;
-                        }
-                    } catch (e) {
-                        document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
-                    }
-                } else {
-                    document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
-                }
-            }).catch(() => {
-                document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
-            });
-        });
-    }
+      var webContext = VSS.getWebContext();
+      var testRunId = tabContext["runId"];
+      var testResultId = tabContext["resultId"];
+      VSS.require(["TFS/TestManagement/RestClient"], function (TestApi) {
+        var client = TestApi.getClient();
+        client.getTestResultById(
+          webContext.project.name,
+          testRunId,
+          testResultId,
+        ).then(result => {
+          var helixWorkItem = TryGetHelix(result.comment);
+          if (helixWorkItem.IsHelixWorkItem) {
+            try {
+              var jobId = helixWorkItem.JobId;
+              var workItemName = helixWorkItem.WorkItemName;
+              var link = "https://helix.dot.net/AzDevExtension/WorkItemResultData?jobName=" + encodeURIComponent(jobId) + "&workItemId=" + encodeURIComponent(workItemName);
+              if (webContext.project.name !== "public") {
+                return VSS.getAppToken().then(tokenObj => {
+                  link += "&extensionToken=" + encodeURIComponent(tokenObj.token);
+                  window.location.href = link;
+                });
+              }
+              else {
+                 window.location.href = link;
+              }
+            } catch (e) {
+              document.getElementById("content").innerHTML = "<h3 style='color: red;'>Unable to Load Helix Data. Please contact <a href=\"mailto:dnceng@microsoft.com\">@dnceng</a>";
+            }
+          }
+          else {
+              document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+          }
+       }).catch(() => {
+          document.getElementById("content").innerHTML = "<h3 style='color: red;'>This is not a helix test, for this reason there are no artifacts available in this tab</h3>";
+       });
+    });
+  }
 
     function TryGetHelix(comment) {
-        if (comment == null) {
-            return { 'IsHelixWorkItem': false };
+      if (comment == null) {
+         return { 'IsHelixWorkItem': false };
+      }
+      try {
+        var data = JSON.parse(comment);
+        var jobId = data.HelixJobId;
+        var workItemName = data.HelixWorkItemName;
+        if (jobId == null || workItemName == null) {
+          return { 'IsHelixWorkItem': false };
         }
-        try {
-            var data = JSON.parse(comment);
-            var jobId = data.HelixJobId;
-            var workItemName = data.HelixWorkItemName;
-            if (jobId == null || workItemName == null) {
-                return { 'IsHelixWorkItem': false };
-            }
-            return {
-                'IsHelixWorkItem': true,
-                'JobId': jobId,
-                'WorkItemName': workItemName
-            };
-        } catch (error) {
-            return { 'IsHelixWorkItem': false };
-        }
+        return {
+          'IsHelixWorkItem': true,
+          'JobId': jobId,
+          'WorkItemName': workItemName
+        };
+      } catch (error) {
+        return { 'IsHelixWorkItem': false };
+      }
     }
 
     // Show context info when ready
     VSS.ready(function () {
-        registerContribution(VSS.getContribution());
-        VSS.notifyLoadSucceeded();
+      registerContribution(VSS.getContribution());
+      VSS.notifyLoadSucceeded();
     });
-</script>
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Customers are confused when they open a non-helix tests, and the artifacts panel just says "Unable to load helix data". We should have a clearer message in this case, something like "This is not a helix test, please use the other tabs"

Issue: https://github.com/dotnet/arcade/issues/8853