### PR TITLE
Use CodeQL 3000 instead of Guardian

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"arcade-extensions",
+    "codebaseName": "arcade-extensions"
+}

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -1,101 +1,56 @@
+parameters:
+  # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
+- name: Codeql.TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
 variables:
-  - name: _TeamName
-    value: DotNetCore
-  - group: SDL_Settings
+  # CG is handled in the primary CI pipeline
+- name: skipComponentGovernanceDetection
+  value: true
+  # Force CodeQL enabled so it may be run on any branch
+- name: Codeql.Enabled
+  value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
+- name: Codeql.Cadence
+  value: 0
+- name: _BuildConfig
+  value: Release
 
 trigger: none
 
 schedules:
   - cron: 0 12 * * 1
-    displayName: Weekly Monday CodeQL/Semmle run
+    displayName: Weekly Monday CodeQL run
     branches:
       include:
       - main
     always: true
 
-stages:
-- stage: CodeQL
+jobs:
+- job: codeql
   displayName: CodeQL
+  pool:
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals windows.vs2019.amd64
 
-  jobs:
-  - job: codeql_windows
-    displayName: CodeQL (Windows)
-    pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals windows.vs2019.amd64
+  steps:
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
 
-    steps:
-    - task: NuGetToolInstaller@1
-      displayName: 'Install NuGet'
+  - task: NodeTool@0
+    displayName: Use Node 10
+    inputs:
+      versionSpec: "10.x"
+
+  # restore
+  - script: restore.cmd
+    displayName: Restore
     
-    - task: NuGetAuthenticate@0
-      displayName: 'Authenticate NuGet'
-      inputs:
-        nuGetServiceConnections: GuardianConnect
+  # Build
+  - script: build.cmd
+    displayName: Build
 
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
-        Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
-      displayName: Install Guardian
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        Initialize-Gdn -GuardianCliLocation $(GuardianCliLocation) `
-          -WorkingDirectory $(Build.SourcesDirectory) `
-          -LoggerLevel 'Standard'
-      displayName: 'CodeQL: Initialize'
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        New-GdnSemmelConfig -GuardianCliLocation $(GuardianCliLocation) `
-          -LoggerLevel 'Standard' `
-          -Language 'javascript' `
-          -WorkingDirectory $(Build.SourcesDirectory) `
-          -SourceCodeDirectory $(Build.SourcesDirectory)\src `
-          -OutputPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig `
-          -AdditionalSemmleParameters @("Typescript < $true")
-      displayName: 'CodeQL: Create Typescript configuration'
-
-    - task: NodeTool@0
-      displayName: Use Node 10
-      inputs:
-        versionSpec: "10.x"
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        Invoke-GdnSemmle -GuardianCliLocation $(GuardianCliLocation) `
-          -LoggerLevel 'Standard' `
-          -WorkingDirectory $(Build.SourcesDirectory) `
-          -ConfigurationPath $(Build.SourcesDirectory)\.gdn\r\semmle-javascript-configure.gdnconfig
-      displayName: 'CodeQL: Typescript'
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        Publish-GdnArtifacts -GuardianCliLocation $(GuardianCliLocation) `
-          -LoggerLevel 'Standard' `
-          -WorkingDirectory $(Build.SourcesDirectory)
-      displayName: Publish results artifact
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        Publish-GdnTsa -GuardianCliLocation $(GuardianCliLocation) `
-          -WorkingDirectory $(Build.SourcesDirectory) `
-          -LoggerLevel 'Standard' `
-          -TsaRepositoryName "arcade-extensions" `
-          -TsaCodebaseName "arcade-extensions" `
-          -TsaCodebaseAdmin $(_TsaCodebaseAdmin) `
-          -TsaNotificationEmail $(_TsaNotificationEmail) `
-          -TsaInstanceUrl $(_TsaInstanceURL) `
-          -TsaProjectName $(_TsaProjectName) `
-          -TsaBugAreaPath $(_TsaBugAreaPath) `
-          -TsaIterationPath $(_TsaIterationPath) `
-          -TsaPublish $true
-      displayName: Publish results to TSA
-
-    - pwsh: |
-        . $(Build.SourcesDirectory)\eng\CodeQL.ps1
-        Invoke-GdnBuildBreak -GuardianCliLocation $(GuardianCliLocation) `
-          -LoggerLevel 'Standard' `
-          -WorkingDirectory $(Build.SourcesDirectory)
-      displayName: Break on failures
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize


### PR DESCRIPTION
Swap Guardian for CodeQL 3000 Azure DevOps extension for CodeQL static code analysis.

Successful test build (minus TSA publish): [Pipelines - Run 2012803](https://dev.azure.com/dnceng/internal/_build/results?buildId=2012803&view=results)

Part of dotnet/arcade#11151