### PR TITLE
Fix tsc toolcheck version

### DIFF
--- a/src/tasks/make.js
+++ b/src/tasks/make.js
@@ -133,7 +133,7 @@ target.gendocs = function() {
 target.build = function() {
     target.clean();
 
-    ensureTool('tsc', '--version', 'Version 4.5.5');
+    ensureTool('tsc', '--version', 'Version 4.9.3');
     ensureTool('npm', '--version', function (output) {
         if (semver.lt(output, '5.6.0')) {
             fail('Expected 5.6.0 or higher. To fix, run: npm install -g npm');


### PR DESCRIPTION
#59 bumped the version of tsc (which is transitive for some reason). The build checks the version, and the difference caused the build to break. It was not caught on PR because the public CI pipeline was not setup after the move to dnceng-public. I've fixed that as well. 