### PR TITLE
remove quote encoding from test results comment field

### DIFF
--- a/src/helix-anon/index.html
+++ b/src/helix-anon/index.html
@@ -93,7 +93,8 @@
             return { 'IsHelixWorkItem': false };
         }
         try {
-            var data = JSON.parse(comment);
+            var escapedComment = comment.replaceAll("$quot;", "\"")
+            var data = JSON.parse(escapedComment);
             var jobId = data.HelixJobId;
             var workItemName = data.HelixWorkItemName;
             if (jobId == null || workItemName == null) {

--- a/src/helix/index.html
+++ b/src/helix/index.html
@@ -101,7 +101,8 @@
          return { 'IsHelixWorkItem': false };
       }
       try {
-        var data = JSON.parse(comment);
+        var escapedComment = comment.replaceAll("$quot;", "\"")
+        var data = JSON.parse(escapedComment);
         var jobId = data.HelixJobId;
         var workItemName = data.HelixWorkItemName;
         if (jobId == null || workItemName == null) {


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13066

The html encoding of the quotes is causing issues with the json parsing inside the extensions.

I tested this change by running the code changes locally in a debug session of the tab, which allowed me to load the artifacts:

![image](https://user-images.githubusercontent.com/23242101/230989247-9803fb98-65a9-4d36-bd4b-b073dd3aa826.png)
