### PR TITLE
Update the retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repo contains the custom build tasks used by dnceng which are distributed in the ["DncEng Build Tasks"](https://marketplace.visualstudio.com/items?itemName=dotnet-dnceng.dnceng-build-release-tasks&targetId=b55de4ed-4b5a-4215-a8e4-0a0a5f71e7d8&utm_source=vstsproduct&utm_medium=ExtHubManageList) extension.
 
+### Public repository retirement notice
+
+WARNING: This project is now in "maintenance" mode. This means that no new features will be accepted and fixes will be limited to security fixes. We expect to retire arcade-extensions by the end of 2024. 
+The project's repository will be archived and there will be no further updates.
+
 ## Overview
 
 [Tasks overview](https://github.com/dotnet/arcade/blob/main/Documentation/Projects/DevOps/Tasks/OnePager.md)


### PR DESCRIPTION
The project will still leave in the mirrored repository. 
However the public version of that repository will be archived. 